### PR TITLE
feat: introduce PulsarReplicateState to the PulsarConsumerSource

### DIFF
--- a/pkg/dblog/resolver.go
+++ b/pkg/dblog/resolver.go
@@ -14,10 +14,11 @@ type SourceResolver interface {
 }
 
 type StaticAgentPulsarURIConfig struct {
-	PulsarURL          string
-	PulsarTopic        string
-	PulsarSubscription string
-	AgentURL           string
+	PulsarURL            string
+	PulsarTopic          string
+	PulsarSubscription   string
+	PulsarReplicateState bool
+	AgentURL             string
 }
 
 func NewStaticAgentPulsarResolver(config map[string]StaticAgentPulsarURIConfig) *StaticAgentPulsarResolver {
@@ -34,9 +35,10 @@ func (r *StaticAgentPulsarResolver) Source(ctx context.Context, uri string) (sou
 		return nil, ErrURINotFound
 	}
 	return &source.PulsarConsumerSource{
-		PulsarOption:       pulsar.ClientOptions{URL: config.PulsarURL},
-		PulsarTopic:        config.PulsarTopic,
-		PulsarSubscription: config.PulsarSubscription,
+		PulsarOption:         pulsar.ClientOptions{URL: config.PulsarURL},
+		PulsarTopic:          config.PulsarTopic,
+		PulsarSubscription:   config.PulsarSubscription,
+		PulsarReplicateState: config.PulsarReplicateState,
 	}, nil
 }
 

--- a/pkg/source/pulsar.go
+++ b/pkg/source/pulsar.go
@@ -151,10 +151,11 @@ func (p *PulsarReaderSource) Commit(cp Checkpoint) {
 type PulsarConsumerSource struct {
 	BaseSource
 
-	PulsarOption       pulsar.ClientOptions
-	PulsarTopic        string
-	PulsarSubscription string
-	PulsarMaxReconnect *uint
+	PulsarOption         pulsar.ClientOptions
+	PulsarTopic          string
+	PulsarSubscription   string
+	PulsarReplicateState bool
+	PulsarMaxReconnect   *uint
 
 	client   pulsar.Client
 	consumer pulsar.Consumer
@@ -173,12 +174,13 @@ func (p *PulsarConsumerSource) Capture(cp Checkpoint) (changes chan Change, err 
 	}
 
 	p.consumer, err = p.client.Subscribe(pulsar.ConsumerOptions{
-		Name:                 host,
-		Topic:                p.PulsarTopic,
-		SubscriptionName:     p.PulsarSubscription,
-		MaxReconnectToBroker: p.PulsarMaxReconnect,
-		ReceiverQueueSize:    ReceiverQueueSize,
-		Type:                 pulsar.Shared, // not use key_shared on xid, because transaction sizes are vary dramatically
+		Name:                       host,
+		Topic:                      p.PulsarTopic,
+		SubscriptionName:           p.PulsarSubscription,
+		ReplicateSubscriptionState: p.PulsarReplicateState,
+		MaxReconnectToBroker:       p.PulsarMaxReconnect,
+		ReceiverQueueSize:          ReceiverQueueSize,
+		Type:                       pulsar.Shared, // not use key_shared on xid, because transaction sizes are vary dramatically
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description
To support the replicated subscription feature of the pulsar geo-replication, the PR added the additional flag `PulsarReplicateState` for setting up the replicated subscriptions.

## Related Document
https://pulsar.apache.org/docs/2.10.x/administration-geo/#replicated-subscriptions