### PR TITLE
feature: ignore the timeout error when reading last messages in pulsar sink

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -166,11 +166,12 @@ func (a *Agent) cleanup() error {
 }
 
 func (a *Agent) pg2pulsar(params *structpb.Struct) (*pb.AgentConfigResponse, error) {
-	v, err := extract(params, "PGConnURL", "PGReplURL", "PulsarURL", "PulsarTopic")
+	v, err := extract(params, "PGConnURL", "PGReplURL", "PulsarURL", "PulsarTopic", "StartLSN")
 	if err != nil {
 		return nil, err
 	}
-	pgSrc := &source.PGXSource{SetupConnStr: v["PGConnURL"], ReplConnStr: v["PGReplURL"], ReplSlot: trimSlot(v["PulsarTopic"]), CreateSlot: true}
+
+	pgSrc := &source.PGXSource{SetupConnStr: v["PGConnURL"], ReplConnStr: v["PGReplURL"], ReplSlot: trimSlot(v["PulsarTopic"]), CreateSlot: true, StartLSN: v["StartLSN"]}
 	pulsarSink := &sink.PulsarSink{PulsarOption: pulsar.ClientOptions{URL: v["PulsarURL"]}, PulsarTopic: v["PulsarTopic"]}
 
 	a.pulsarSink = pulsarSink

--- a/pkg/sink/pulsar.go
+++ b/pkg/sink/pulsar.go
@@ -61,7 +61,16 @@ func (p *PulsarSink) Setup() (cp source.Checkpoint, err error) {
 			}
 			p.prev = cp
 		}
-		if err != nil && err != context.DeadlineExceeded {
+		if err != nil {
+			if err != context.DeadlineExceeded {
+				p.log.WithFields(logrus.Fields{
+					"PulsarTopic": p.PulsarTopic,
+				}).Info("fail to read last message from pulsar")
+
+				// ignore the timeout error and return the empty checkpoint
+				return cp, nil
+			}
+
 			return cp, err
 		}
 	}


### PR DESCRIPTION
## Description
So the pg2pulsar will not get stuck when not being able to read the latest message from the topic.