### PR TITLE
fix: should use commit lsn

### DIFF
--- a/pkg/source/postgres.go
+++ b/pkg/source/postgres.go
@@ -181,8 +181,8 @@ func (p *PGXSource) fetching(ctx context.Context) (change Change, err error) {
 				p.currentLsn = b.FinalLsn
 				p.currentSeq = 0
 			} else if c := m.GetCommit(); c != nil {
-				p.currentLsn = c.EndLsn
-				p.currentSeq = 0
+				p.currentLsn = c.CommitLsn
+				p.currentSeq++
 			}
 			change = Change{
 				Checkpoint: cursor.Checkpoint{LSN: p.currentLsn, Seq: p.currentSeq},

--- a/pkg/source/postgres_test.go
+++ b/pkg/source/postgres_test.go
@@ -210,7 +210,7 @@ func readTx(t *testing.T, changes chan Change, n int) (tx Tx) {
 		t.Fatalf("unexpected %v", m.Message.String())
 	} else {
 		commit := m.Message.GetCommit()
-		if m.Checkpoint.LSN != commit.EndLsn || m.Checkpoint.Seq != 0 || commit.EndLsn <= finalLSN {
+		if m.Checkpoint.LSN != commit.CommitLsn || m.Checkpoint.Seq != 0 || commit.CommitLsn != finalLSN {
 			t.Fatalf("unexpected commit checkpoint %v", m.Checkpoint)
 		}
 		tx.Commit = m


### PR DESCRIPTION
we know begin finalLSN = commit commitLSN and commit endLSN > commit commitLSN.
So, we can just send commitLSN in PG source and we can correctly compare LSN in Pulsar source