### PR TITLE
fix: fix the agent.pg2pulsar related issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN go mod download
 ADD . .
 
 ARG SHA
-RUN go build -ldflags="-X github.com/rueian/pgcapture/cmd.CommitSHA=${SHA}" -x -o pgcapture main.go
+ARG VERSION
+RUN go build -ldflags="-X github.com/rueian/pgcapture/cmd.CommitSHA=${SHA} -X github.com/rueian/pgcapture/cmd.Version=${VERSION}" -x -o pgcapture main.go
 
 FROM gcr.io/distroless/base-debian10
 

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -179,7 +179,7 @@ func (a *Agent) pg2pulsar(params *structpb.Struct) (*pb.AgentConfigResponse, err
 	switch v["PulsarTracker"] {
 	case "pulsar", "":
 		pulsarSink.SetupTracker = func(client pulsar.Client, topic string) (cursor.Tracker, error) {
-			return &cursor.PulsarTracker{Client: client, PulsarTopic: topic}, nil
+			return cursor.NewPulsarTracker(client, topic)
 		}
 	case "pulsarSub":
 		pulsarSink.SetupTracker = func(client pulsar.Client, topic string) (cursor.Tracker, error) {

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -12,13 +12,15 @@ import (
 )
 
 var (
-	AgentAddr         string
-	AgentCommand      string
-	ConfigPGConnURL   string
-	ConfigPGReplURL   string
-	ConfigPulsarURL   string
-	ConfigPulsarTopic string
-	ConfigPGLogPath   string
+	AgentAddr           string
+	AgentCommand        string
+	ConfigPGConnURL     string
+	ConfigPGReplURL     string
+	ConfigPulsarURL     string
+	ConfigPulsarTopic   string
+	ConfigPGLogPath     string
+	ConfigStartLSN      string
+	ConfigPulsarTracker string
 )
 
 func init() {
@@ -30,6 +32,8 @@ func init() {
 	configure.Flags().StringVarP(&ConfigPulsarURL, "PulsarURL", "", "", "connection url to sink pulsar cluster")
 	configure.Flags().StringVarP(&ConfigPulsarTopic, "PulsarTopic", "", "", "the sink pulsar topic name and as well as the logical replication slot name")
 	configure.Flags().StringVarP(&ConfigPGLogPath, "PGLogPath", "", "", "pg log path for finding last checkpoint lsn")
+	configure.Flags().StringVarP(&ConfigStartLSN, "StartLSN", "", "", "the LSN position to start the pg2pulsar process, optional")
+	configure.Flags().StringVarP(&ConfigPulsarTracker, "PulsarTracker", "", "", "the tracker type for pg2pulsar, optional")
 	configure.MarkFlagRequired("AgentAddr")
 	configure.MarkFlagRequired("AgentCommand")
 	configure.MarkFlagRequired("PGConnURL")
@@ -42,12 +46,14 @@ var configure = &cobra.Command{
 	Short: "Poke agent's Configure endpoint repeatedly",
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		params, err := structpb.NewStruct(map[string]interface{}{
-			"Command":     AgentCommand,
-			"PGConnURL":   ConfigPGConnURL,
-			"PGReplURL":   ConfigPGReplURL,
-			"PulsarURL":   ConfigPulsarURL,
-			"PulsarTopic": ConfigPulsarTopic,
-			"PGLogPath":   ConfigPGLogPath,
+			"Command":       AgentCommand,
+			"PGConnURL":     ConfigPGConnURL,
+			"PGReplURL":     ConfigPGReplURL,
+			"PulsarURL":     ConfigPulsarURL,
+			"PulsarTopic":   ConfigPulsarTopic,
+			"PGLogPath":     ConfigPGLogPath,
+			"StartLSN":      ConfigStartLSN,
+			"PulsarTracker": ConfigPulsarTracker,
 		})
 		if err != nil {
 			panic(err)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,6 +7,7 @@ import (
 )
 
 var CommitSHA string
+var Version string
 
 func init() {
 	rootCmd.AddCommand(version)
@@ -16,7 +17,7 @@ var version = &cobra.Command{
 	Use:   "version",
 	Short: "git commit version",
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
-		fmt.Println(CommitSHA)
+		fmt.Printf("version: %s (%s)", Version, CommitSHA)
 		return nil
 	},
 }

--- a/pkg/cursor/main.go
+++ b/pkg/cursor/main.go
@@ -52,3 +52,18 @@ func ToCheckpoint(msg pulsar.Message) (cp Checkpoint, err error) {
 	cp.Data = msg.ID().Serialize()
 	return
 }
+
+// Since only the reader can guarantee not to create the partitioned topic(s),
+// we use the reader creation to ensure the existence of the specified topic
+func ensureTopic(client pulsar.Client, topic string) error {
+	reader, err := client.CreateReader(pulsar.ReaderOptions{
+		Name:           topic + "-temp-reader",
+		Topic:          topic,
+		StartMessageID: pulsar.LatestMessageID(),
+	})
+	if err != nil {
+		return err
+	}
+	reader.Close()
+	return nil
+}

--- a/pkg/cursor/pulsar_sub.go
+++ b/pkg/cursor/pulsar_sub.go
@@ -57,6 +57,10 @@ func (p *PulsarSubscriptionTracker) waitCommit(ctx context.Context, interval tim
 }
 
 func NewPulsarSubscriptionTracker(client pulsar.Client, topic string, commitInterval time.Duration) (*PulsarSubscriptionTracker, error) {
+	if err := ensureTopic(client, topic); err != nil {
+		return nil, err
+	}
+
 	consumer, err := client.Subscribe(pulsar.ConsumerOptions{
 		Name:             "pulsar-subscription-tracker",
 		Topic:            topic,


### PR DESCRIPTION
## Description
The PR fixed the agent.pg2pulsar command related issues, including:
1. not forwarding the StartLSN/PulsarTracker params from the configure command
2. creating partitioned topics unexpectedly by the pulsarSubscriptionTracker 

As for the 2nd issue, the PR utilized the reader interface to ensure the existance **non-partitioned** topic (for passing the CDC events),
so the implementations added the additional steps to setup the reader before creating the producer/tracking-consumer.

The PR also adjusted the version command by adding more version info.