### PR TITLE
feat: adjust the subscription name of the pulsar subscription cursor

### DIFF
--- a/pkg/cursor/pulsar_sub.go
+++ b/pkg/cursor/pulsar_sub.go
@@ -64,7 +64,7 @@ func NewPulsarSubscriptionTracker(client pulsar.Client, topic string, commitInte
 	consumer, err := client.Subscribe(pulsar.ConsumerOptions{
 		Name:             "pulsar-subscription-tracker",
 		Topic:            topic,
-		SubscriptionName: topic + "-cursor-consumer",
+		SubscriptionName: "pulsar-subscription-tracker-consumer",
 		Type:             pulsar.Exclusive,
 	})
 

--- a/pkg/cursor/pulsar_sub_test.go
+++ b/pkg/cursor/pulsar_sub_test.go
@@ -88,7 +88,7 @@ func TestPulsarSubscriptionTracker_Commit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cursor, err := CheckSubscriptionCursor(admin, topic, topic+"-cursor-consumer")
+	cursor, err := CheckSubscriptionCursor(admin, topic, "pulsar-subscription-tracker-consumer")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Description
So we can access the subscription info from the pulsar-manager-ui panels.