### PR TITLE
feat: introduce PulsarTrackerInterval to the agent command

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -182,7 +182,8 @@ func (a *Agent) pg2pulsar(params *structpb.Struct) (*pb.AgentConfigResponse, err
 			return cursor.NewPulsarTracker(client, topic)
 		}
 	case "pulsarSub":
-		commitInterval := 10 * time.Minute
+		// set the default value to 1min
+		commitInterval := time.Minute
 		if val := v["PulsarTrackerInterval"]; val != "" {
 			var err error
 			commitInterval, err = time.ParseDuration(val)


### PR DESCRIPTION
## Description
In previous implementations, the pulsarSub tracker type could cause significant backlog issues when the input rate of the associated topic is high. This occurs because the cursor is only updated every 10 minutes.
To address this issue, the PR introduces a new flag called `PulsarTrackerInterval`, which allows for adjusting the update interval. The PR also set the default value of the commit interval to be 1min.