### PR TITLE
feat: support generated columns

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,9 +38,16 @@ jobs:
       - checkout
       - test-with-pg:
           version: 12
+  test-pg-13:
+    executor: default
+    steps:
+      - checkout
+      - test-with-pg:
+          version: 13
 
 workflows:
   test:
     jobs:
       - test-pg-11
       - test-pg-12
+      - test-pg-13

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,21 @@
-version: 2
-jobs:
-  build:
+version: 2.1
+
+
+executors:
+  default:
     machine:
       image: ubuntu-2004:202010-01
+
+commands:
+  test-with-pg:
+    parameters:
+      version:
+        type: integer
+        default: 11
     steps:
-      - checkout
-      - run: docker-compose pull pg
-      - run: docker-compose up -d --no-build
+      - run: docker-compose pull pg_<< parameters.version >>
+      - run: docker-compose up -d --no-build pulsar
+      - run: docker-compose up -d --no-build pg_<< parameters.version >>
       - run: curl -L https://golang.org/dl/go1.20.linux-amd64.tar.gz > /tmp/go1.20.linux-amd64.tar.gz
       - run: tar -C /tmp -xzf /tmp/go1.20.linux-amd64.tar.gz
       - run: curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
@@ -15,3 +24,23 @@ jobs:
       - run: ./cc-test-reporter before-build
       - run: /tmp/go/bin/go test -race -p 1 -coverprofile=./c.out ./...
       - run: ./cc-test-reporter after-build -p $(go list -m) --exit-code $?
+
+jobs:
+  test-pg-11:
+    executor: default
+    steps:
+      - checkout
+      - test-with-pg:
+          version: 11
+  test-pg-12:
+    executor: default
+    steps:
+      - checkout
+      - test-with-pg:
+          version: 12
+
+workflows:
+  test:
+    jobs:
+      - test-pg-11
+      - test-pg-12

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A scalable Netflix DBLog implementation for PostgreSQL
 * pglogical postgresql extension
 * pgcapture postgresql extension
 
-See [./hack/postgres/Dockerfile](./hack/postgres/Dockerfile) for installation guide.
+See [./hack/postgres/Dockerfile](./hack/postgres/Dockerfile.11) for installation guide.
   
 ## Consume changes with Golang
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,25 @@
 version: "3.8"
+
+x-common-pg: &common-pg
+  build: hack/postgres
+  ports:
+    - "5432:5432"
+  command: [ "postgres", "-c", "config_file=/pgc/postgresql.conf", "-c","hba_file=/pgc/pg_hba.conf" ]
+  environment:
+    POSTGRES_HOST_AUTH_METHOD: trust
+  volumes:
+    - ./hack/postgres:/pgc
+
 services:
   pg_11:
-    build: hack/postgres
+    <<: *common-pg
     image: rueian/postgres:11-logical
-    ports:
-      - "5432:5432"
-    command: ["postgres", "-c", "config_file=/pgc/postgresql.conf", "-c","hba_file=/pgc/pg_hba.conf"]
-    environment:
-      POSTGRES_HOST_AUTH_METHOD: trust
-    volumes:
-      - ./hack/postgres:/pgc
   pg_12:
-    build: hack/postgres
+    <<: *common-pg
     image: dcard/postgres:12-logical
-    ports:
-      - "5432:5432"
-    command: [ "postgres", "-c", "config_file=/pgc/postgresql.conf", "-c","hba_file=/pgc/pg_hba.conf" ]
-    environment:
-      POSTGRES_HOST_AUTH_METHOD: trust
-    volumes:
-      - ./hack/postgres:/pgc
+  pg_13:
+    <<: *common-pg
+    image: dcard/postgres:13-logical
   pulsar:
     image: apachepulsar/pulsar:2.10.4
     command: ["bin/pulsar", "standalone"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,21 @@
 version: "3.8"
 services:
-  pg:
+  pg_11:
     build: hack/postgres
     image: rueian/postgres:11-logical
     ports:
       - "5432:5432"
     command: ["postgres", "-c", "config_file=/pgc/postgresql.conf", "-c","hba_file=/pgc/pg_hba.conf"]
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+    volumes:
+      - ./hack/postgres:/pgc
+  pg_12:
+    build: hack/postgres
+    image: dcard/postgres:12-logical
+    ports:
+      - "5432:5432"
+    command: [ "postgres", "-c", "config_file=/pgc/postgresql.conf", "-c","hba_file=/pgc/pg_hba.conf" ]
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
     volumes:

--- a/hack/postgres/Dockerfile.11
+++ b/hack/postgres/Dockerfile.11
@@ -1,0 +1,17 @@
+FROM --platform=$TARGETPLATFORM postgres:11-alpine
+ARG TARGETPLATFORM
+
+RUN wget https://github.com/rueian/pglogical/archive/REL2_3_4_no_filter.tar.gz && \
+    tar -zxvf REL2_3_4_no_filter.tar.gz && \
+    apk -U add --no-cache build-base libxslt-dev libxml2-dev openssl-dev libedit-dev zlib-dev $DOCKER_PG_LLVM_DEPS krb5-pkinit krb5-dev krb5 && \
+    cd /pglogical-REL2_3_4_no_filter && \
+    make USE_PGXS=1 CPPFLAGS="-DPGL_NO_STDIN_ASSIGN" clean all && \
+    make install && \
+    cd / && \
+    rm -rf /REL2_3_4_no_filter.tar.gz /pglogical-REL2_3_4_no_filter
+
+RUN chown -R postgres:postgres /usr/local/share/postgresql/extension
+RUN chown -R postgres:postgres /usr/local/lib/postgresql
+
+COPY ./extension /extension
+RUN cd /extension && ./make.sh

--- a/hack/postgres/Dockerfile.12
+++ b/hack/postgres/Dockerfile.12
@@ -1,8 +1,8 @@
-FROM postgres:11-alpine
+FROM postgres:12-alpine
 
 RUN wget https://github.com/rueian/pglogical/archive/REL2_3_4_no_filter.tar.gz && \
     tar -zxvf REL2_3_4_no_filter.tar.gz && \
-    apk -U add --no-cache build-base libxslt-dev libxml2-dev openssl-dev libedit-dev zlib-dev postgresql-dev krb5-pkinit krb5-dev krb5 && \
+    apk -U add --no-cache build-base libxslt-dev libxml2-dev openssl-dev libedit-dev zlib-dev $DOCKER_PG_LLVM_DEPS krb5-pkinit krb5-dev krb5 && \
     cd /pglogical-REL2_3_4_no_filter && \
     make USE_PGXS=1 CPPFLAGS="-DPGL_NO_STDIN_ASSIGN" clean all && \
     make install && \

--- a/hack/postgres/Dockerfile.12
+++ b/hack/postgres/Dockerfile.12
@@ -1,4 +1,5 @@
-FROM postgres:12-alpine
+FROM --platform=$TARGETPLATFORM postgres:12-alpine
+ARG TARGETPLATFORM
 
 RUN wget https://github.com/rueian/pglogical/archive/REL2_3_4_no_filter.tar.gz && \
     tar -zxvf REL2_3_4_no_filter.tar.gz && \

--- a/hack/postgres/Dockerfile.13
+++ b/hack/postgres/Dockerfile.13
@@ -1,8 +1,9 @@
-FROM postgres:11-alpine
+FROM --platform=$TARGETPLATFORM postgres:13-alpine
+ARG TARGETPLATFORM
 
 RUN wget https://github.com/rueian/pglogical/archive/REL2_3_4_no_filter.tar.gz && \
     tar -zxvf REL2_3_4_no_filter.tar.gz && \
-    apk -U add --no-cache build-base libxslt-dev libxml2-dev openssl-dev libedit-dev zlib-dev postgresql-dev krb5-pkinit krb5-dev krb5 && \
+    apk -U add --no-cache build-base libxslt-dev libxml2-dev openssl-dev libedit-dev zlib-dev $DOCKER_PG_LLVM_DEPS krb5-pkinit krb5-dev krb5 && \
     cd /pglogical-REL2_3_4_no_filter && \
     make USE_PGXS=1 CPPFLAGS="-DPGL_NO_STDIN_ASSIGN" clean all && \
     make install && \

--- a/hack/postgres/dockerbuild.sh
+++ b/hack/postgres/dockerbuild.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+export DOCKER_BUILDKIT=1
+
+VERSION="${VERSION:-11}"
+TAG="dcard/postgres:$VERSION-logical"
+
+echo "build for $TAG"
+docker buildx build --push --platform=linux/amd64 -t $TAG -f "Dockerfile.$VERSION" .

--- a/pkg/decode/schema.go
+++ b/pkg/decode/schema.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/jackc/pgtype"
 	"github.com/jackc/pgx/v4"
@@ -96,6 +97,18 @@ func (p *PGXSchemaLoader) GetTableKey(namespace, table string) (keys []string, e
 		return nil, fmt.Errorf("%s.%s %w", namespace, table, ErrSchemaIdentityMissing)
 	}
 	return keys, nil
+}
+
+func (p *PGXSchemaLoader) GetVersion() (version int64, err error) {
+	var versionInfo string
+	if err = p.conn.QueryRow(context.Background(), sql.ServerVersionNum).Scan(&versionInfo); err != nil {
+		return -1, err
+	}
+	svn, err := strconv.ParseInt(versionInfo, 10, 64)
+	if err != nil {
+		return -1, err
+	}
+	return svn, nil
 }
 
 var (

--- a/pkg/decode/schema.go
+++ b/pkg/decode/schema.go
@@ -34,6 +34,10 @@ func (s *fieldSet) append(f string) {
 }
 
 func (s *fieldSet) list() []string {
+	if s == nil {
+		return []string{}
+	}
+
 	list := make([]string, 0, len(s.set))
 	for k := range s.set {
 		list = append(list, k)

--- a/pkg/decode/schema_test.go
+++ b/pkg/decode/schema_test.go
@@ -119,7 +119,13 @@ func TestSchemaLoader(t *testing.T) {
 				}
 			}
 
-			for _, c := range append(table.identityGenerations, table.generated...) {
+			for _, c := range table.identityGenerations {
+				if !info.IsIdentityGeneration(c) {
+					t.Fatalf("The column: %s should be identity generated", c)
+				}
+			}
+
+			for _, c := range table.generated {
 				if !info.IsGenerated(c) {
 					t.Fatalf("The column: %s should be generated", c)
 				}

--- a/pkg/decode/schema_test.go
+++ b/pkg/decode/schema_test.go
@@ -108,8 +108,8 @@ func TestSchemaLoader(t *testing.T) {
 			}
 		}
 
-		if err = schema.RefreshKeys(); err != nil {
-			t.Fatalf("RefreshKeys fail: %v", err)
+		if err = schema.RefreshColumnInfo(); err != nil {
+			t.Fatalf("RefreshColumnInfo fail: %v", err)
 		}
 		for i, table := range tables {
 			keys, err := schema.GetTableKey("public", "t"+strconv.Itoa(i))

--- a/pkg/decode/schema_test.go
+++ b/pkg/decode/schema_test.go
@@ -62,73 +62,135 @@ func TestSchemaLoader(t *testing.T) {
 		}
 	})
 
-	t.Run("GetTableKey", func(t *testing.T) {
-		tables := []struct {
-			Primary []string
-			Uniques []string
-		}{
-			{
-				Primary: []string{"a"},
-			},
-			{
-				Uniques: []string{"a", "b"},
-			},
-			{
-				Primary: []string{"a", "b"},
-				Uniques: []string{"c", "d"},
-			},
+	t.Run("GetColumnInfo", func(t *testing.T) {
+		tables := []tableFixture{
 			{
 				// empty
 			},
+			{
+				primary: []string{"a"},
+			},
+			{
+				uniques: []string{"a", "b"},
+			},
+			{
+				primary: []string{"a", "b"},
+				uniques: []string{"c", "d"},
+			},
+			{
+				primary:             []string{"a"},
+				identityGenerations: []string{"a"},
+			},
+			// TODO: what for the supports for pg12 and above
+			//{
+			//	primary:   []string{"a"},
+			//	generated: []string{"b", "c"},
+			//},
 		}
 
 		for i, table := range tables {
-			var columns []string
-			for _, c := range table.Primary {
-				columns = append(columns, c+" int")
-			}
-			for _, c := range table.Uniques {
-				columns = append(columns, c+" int")
-			}
-			for j := 0; j < 3; j++ {
-				columns = append(columns, fmt.Sprintf("c%d int", j))
-			}
-			if _, err = conn.Exec(ctx, fmt.Sprintf("create table t%d (%s)", i, strings.Join(columns, ","))); err != nil {
+			if err = table.create(ctx, conn, i); err != nil {
 				t.Fatal(err)
-			}
-			if len(table.Primary) > 0 {
-				if _, err = conn.Exec(ctx, fmt.Sprintf("alter table t%d add constraint t%dp primary key (%s)", i, i, strings.Join(table.Primary, ","))); err != nil {
-					t.Fatal(err)
-				}
-			}
-			if len(table.Uniques) > 0 {
-				if _, err = conn.Exec(ctx, fmt.Sprintf("alter table t%d add constraint t%du unique (%s)", i, i, strings.Join(table.Uniques, ","))); err != nil {
-					t.Fatal(err)
-				}
 			}
 		}
 
 		if err = schema.RefreshColumnInfo(); err != nil {
 			t.Fatalf("RefreshColumnInfo fail: %v", err)
 		}
+
 		for i, table := range tables {
-			keys, err := schema.GetTableKey("public", "t"+strconv.Itoa(i))
-			if len(table.Primary) > 0 {
-				if !match(keys, table.Primary) {
-					t.Fatalf("GetTableKey not match on %s %v %v", "t"+strconv.Itoa(i), keys, table.Primary)
+			info, err := schema.GetColumnInfo("public", "t"+strconv.Itoa(i))
+			if len(table.primary) == 0 && len(table.uniques) == 0 && len(table.identityGenerations) == 0 {
+				// the empty table: should get the schema identity missing error
+				if !errors.Is(err, ErrSchemaIdentityMissing) {
+					t.Fatalf("unexpected %v", err)
 				}
-			} else if len(table.Uniques) > 0 {
-				if !match(keys, table.Uniques) {
-					t.Fatalf("GetTableKey not match on %s %v %v", "t"+strconv.Itoa(i), keys, table.Uniques)
+				continue
+			}
+
+			keys := info.ListKeys()
+			if len(table.primary) > 0 {
+				if !match(keys, table.primary) {
+					t.Fatalf("GetTableKey not match on %s %v %v", "t"+strconv.Itoa(i), keys, table.primary)
 				}
-			} else if !errors.Is(err, ErrSchemaIdentityMissing) {
-				t.Fatal(err)
+			} else if len(table.uniques) > 0 {
+				if !match(keys, table.uniques) {
+					t.Fatalf("GetTableKey not match on %s %v %v", "t"+strconv.Itoa(i), keys, table.uniques)
+				}
+			}
+
+			for _, c := range append(table.identityGenerations, table.generated...) {
+				if !info.IsGenerated(c) {
+					t.Fatalf("The column: %s should be generated", c)
+				}
 			}
 		}
 		if _, err = schema.GetTableKey("other", "other"); !errors.Is(err, ErrSchemaIdentityMissing) {
 			t.Fatalf("unexpected %v", err)
 		}
 	})
+
+	t.Run("GetVersion", func(t *testing.T) {
+		if _, err := schema.GetVersion(); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+type tableFixture struct {
+	primary             []string
+	uniques             []string
+	identityGenerations []string
+	generated           []string
+}
+
+func (t tableFixture) create(ctx context.Context, conn *pgx.Conn, tag int) (err error) {
+	var columns []string
+	for _, c := range t.primary {
+		columns = append(columns, c+" int")
+	}
+	for _, c := range t.uniques {
+		columns = append(columns, c+" int")
+	}
+	for j := 0; j < 3; j++ {
+		columns = append(columns, fmt.Sprintf("c%d int", j))
+	}
+	if _, err = conn.Exec(ctx, fmt.Sprintf("create table t%d (%s)", tag, strings.Join(columns, ","))); err != nil {
+		return
+	}
+
+	if len(t.primary) > 0 {
+		q := fmt.Sprintf("alter table t%d add constraint t%dp primary key (%s)", tag, tag, strings.Join(t.primary, ","))
+		if _, err = conn.Exec(ctx, q); err != nil {
+			return
+		}
+	}
+
+	for _, c := range t.identityGenerations {
+		q := fmt.Sprintf("alter table t%d alter column %s add generated always as identity", tag, c)
+		if _, err = conn.Exec(ctx, q); err != nil {
+			return
+		}
+	}
+
+	if len(t.uniques) > 0 {
+		q := fmt.Sprintf("alter table t%d add constraint t%du unique (%s)", tag, tag, strings.Join(t.uniques, ","))
+		if _, err = conn.Exec(ctx, q); err != nil {
+			return
+		}
+	}
+
+	for _, g := range t.generated {
+		q := fmt.Sprintf("alter table t%d add column %s int generated always as (c0 * 2) stored", tag, g)
+		if _, err = conn.Exec(ctx, q); err != nil {
+			fmt.Println("failed to exec alter table", q, "\n", err)
+			return
+		}
+	}
+
+	// TODO: handle the identity generation columns
+
+	return
 }
 
 var pgTypeNames = []string{

--- a/pkg/sink/postgres.go
+++ b/pkg/sink/postgres.go
@@ -422,7 +422,15 @@ func (p *PGXSink) flushInsert(ctx context.Context) (err error) {
 
 	keys, _ := p.schema.GetTableKey(p.inserts.Schema, p.inserts.Table)
 
-	return p.raw.ExecParams(ctx, sql.InsertQuery(p.inserts.Schema, p.inserts.Table, keys, batch[0], len(batch)), vals, oids, fmts, rets).Read().Err
+	opt := sql.InsertOption{
+		Namespace: p.inserts.Schema,
+		Table:     p.inserts.Table,
+		Keys:      keys,
+		Fields:    batch[0],
+		Count:     len(batch),
+		PGVersion: p.pgVersion,
+	}
+	return p.raw.ExecParams(ctx, sql.InsertQuery(opt), vals, oids, fmts, rets).Read().Err
 }
 
 func (p *PGXSink) handleInsert(ctx context.Context, m *pb.Change) (err error) {

--- a/pkg/sink/postgres.go
+++ b/pkg/sink/postgres.go
@@ -393,7 +393,7 @@ func (p *PGXSink) flushInsert(ctx context.Context) (err error) {
 	}
 
 	info, _ := p.schema.GetColumnInfo(p.inserts.Schema, p.inserts.Table)
-	cols, filtered := info.Filter(batch[0], func(i *decode.ColumnInfo, field string) bool {
+	cols, filtered := info.Filter(batch[0], func(i decode.ColumnInfo, field string) bool {
 		return !i.IsGenerated(field)
 	})
 
@@ -496,7 +496,7 @@ func (p *PGXSink) handleUpdate(ctx context.Context, m *pb.Change) (err error) {
 	)
 	if m.Old != nil {
 		keys = m.Old
-		_, sets = info.Filter(m.New, func(i *decode.ColumnInfo, field string) bool {
+		_, sets = info.Filter(m.New, func(i decode.ColumnInfo, field string) bool {
 			return !i.IsGenerated(field) && !i.IsIdentityGeneration(field)
 		})
 	} else {

--- a/pkg/sql/builder.go
+++ b/pkg/sql/builder.go
@@ -46,11 +46,11 @@ func UpdateQuery(namespace, table string, sets, keys []*pb.Field) string {
 	query.WriteString(" where \"")
 
 	for i := 0; i < len(keys); i++ {
-		j = i + j
+		k := i + j
 		field := keys[i]
 
 		query.WriteString(field.Name)
-		query.WriteString("\"=$" + strconv.Itoa(j+1))
+		query.WriteString("\"=$" + strconv.Itoa(k+1))
 		if i != len(keys)-1 {
 			query.WriteString(" and \"")
 		}

--- a/pkg/sql/builder_test.go
+++ b/pkg/sql/builder_test.go
@@ -7,17 +7,48 @@ import (
 )
 
 func TestInsertQuery(t *testing.T) {
-	q := InsertQuery("public", "my_table", nil, []*pb.Field{{Name: "f1"}, {Name: "f2"}}, 4)
+	opt := InsertOption{
+		Namespace: "public",
+		Table:     "my_table",
+		Fields:    []*pb.Field{{Name: "f1"}, {Name: "f2"}},
+		Count:     4,
+	}
+
+	q := InsertQuery(opt)
 	if q != `insert into "public"."my_table"("f1","f2") values ($1,$2),($3,$4),($5,$6),($7,$8)` {
 		t.Fatalf("not expected %q", q)
 	}
 }
 
-func TestInsertQueryConflick(t *testing.T) {
-	q := InsertQuery("public", "my_table", []string{"id", "name"}, []*pb.Field{{Name: "f1"}, {Name: "f2"}}, 4)
+func TestInsertQueryConflict(t *testing.T) {
+	opt := InsertOption{
+		Namespace: "public",
+		Table:     "my_table",
+		Keys:      []string{"id", "name"},
+		Fields:    []*pb.Field{{Name: "f1"}, {Name: "f2"}},
+		Count:     4,
+	}
+
+	q := InsertQuery(opt)
 	if q != `insert into "public"."my_table"("f1","f2") values ($1,$2),($3,$4),($5,$6),($7,$8) ON CONFLICT (id,name) DO NOTHING` {
 		t.Fatalf("not expected %q", q)
 	}
+}
+
+func TestInsertQueryOverridingSystemValue(t *testing.T) {
+	opt := InsertOption{
+		Namespace: "public",
+		Table:     "my_table",
+		Fields:    []*pb.Field{{Name: "f1"}, {Name: "f2"}},
+		Count:     4,
+		PGVersion: 100000,
+	}
+
+	q := InsertQuery(opt)
+	if q != `insert into "public"."my_table"("f1","f2") OVERRIDING SYSTEM VALUE values ($1,$2),($3,$4),($5,$6),($7,$8)` {
+		t.Fatalf("not expected %q", q)
+	}
+
 }
 
 func TestDeleteQuery(t *testing.T) {

--- a/pkg/sql/source.go
+++ b/pkg/sql/source.go
@@ -6,7 +6,12 @@ JOIN pg_catalog.pg_class c ON c.relnamespace = n.oid AND c.relkind = 'r'
 JOIN pg_catalog.pg_attribute a ON a.attrelid = c.oid AND a.attnum > 0 and a.attisdropped = false
 WHERE n.nspname NOT IN ('pg_catalog', 'information_schema', 'pglogical') AND n.nspname !~ '^pg_toast';`
 
-var QueryIdentityKeys = `SELECT nspname, relname, array(select attname from pg_catalog.pg_attribute where attrelid = i.indrelid AND attnum > 0 AND attnum = ANY(i.indkey)) as keys
+var QueryIdentityKeys = `SELECT
+	nspname,
+	relname,
+	array(select attname from pg_catalog.pg_attribute where attrelid = i.indrelid AND attnum > 0 AND attnum = ANY(i.indkey)) as keys,
+	array(select column_name::text from information_schema.columns where table_schema = n.nspname AND table_name = c.relname AND identity_generation IS NOT NULL) as identity_generation_columns,
+	array(select column_name::text from information_schema.columns where table_schema = n.nspname AND table_name = c.relname AND is_generated = 'ALWAYS') as generated_columns
 FROM pg_catalog.pg_index i
 JOIN pg_catalog.pg_class c ON c.oid = i.indrelid AND c.relkind = 'r'
 JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace AND n.nspname NOT IN ('pg_catalog', 'information_schema', 'pglogical') AND n.nspname !~ '^pg_toast'


### PR DESCRIPTION
## Description
The PR is for supporting the generated identity and the generated columns.

### Test against different PG versions
Since the `GENERATED ALWAYS AS (...)` is supported only for the pg12 or above,
the PR adjusted the related tests/configs to:

1. support testing against different pg versions (i.e. pg11, pg12, and pg13).
2. support running different tests against different versions (with the min pg version specified by the test case itself).

Also the new Dockerfile and the build script are introduced in the PR to support building different version of pg with pglogical.

## Related issues
to solve #27 