### PR TITLE
fix: fix the glib compatibility related issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ADD . .
 
 ARG SHA
 ARG VERSION
-RUN go build -ldflags="-X github.com/rueian/pgcapture/cmd.CommitSHA=${SHA} -X github.com/rueian/pgcapture/cmd.Version=${VERSION}" -x -o pgcapture main.go
+RUN go build -ldflags="-extldflags=-static -X github.com/rueian/pgcapture/cmd.CommitSHA=${SHA} -X github.com/rueian/pgcapture/cmd.Version=${VERSION}" -x -o pgcapture main.go
 
 FROM gcr.io/distroless/base-debian10
 


### PR DESCRIPTION
## Description
The PR is for solving the compatibility issue after migrating to go 1.20.
To solve the issue, the PR added the `-extldflags=-static` flag when building the pgcapture binary.

