### PR TITLE
feat: support consumser source other than DBLogGatewayConsumer

### DIFF
--- a/example/client/main.go
+++ b/example/client/main.go
@@ -32,7 +32,7 @@ func main() {
 	}
 	defer conn.Close()
 
-	consumer := pgcapture.NewConsumer(context.Background(), conn, pgcapture.ConsumerOption{
+	consumer := pgcapture.NewDBLogConsumer(context.Background(), conn, pgcapture.ConsumerOption{
 		URI:              example.SrcDB.DB,
 		TableRegex:       example.TestTable,
 		DebounceInterval: time.Second,

--- a/pkg/pgcapture/consumer_test.go
+++ b/pkg/pgcapture/consumer_test.go
@@ -33,9 +33,11 @@ func testBounceInterval(t *testing.T, interval time.Duration) {
 		sendQ: make(chan *pb.CaptureRequest),
 		recvQ: make(chan *pb.CaptureMessage),
 	}
-	consumer := newConsumer(ctx, mock, ConsumerOption{
-		URI:              "uri",
-		TableRegex:       "regex",
+	src := newDBogGatewaySource(ctx, mock, ConsumerOption{
+		URI:        "uri",
+		TableRegex: "regex",
+	})
+	consumer := newConsumer(ctx, src, ConsumerOption{
 		DebounceInterval: interval,
 		OnDecodeError: func(source source.Change, err error) {
 		},
@@ -148,9 +150,11 @@ func testBounceIntervalRequeue(t *testing.T, interval time.Duration) {
 		sendQ: make(chan *pb.CaptureRequest),
 		recvQ: make(chan *pb.CaptureMessage),
 	}
-	consumer := newConsumer(ctx, mock, ConsumerOption{
-		URI:              "uri",
-		TableRegex:       "regex",
+	src := newDBogGatewaySource(ctx, mock, ConsumerOption{
+		URI:        "uri",
+		TableRegex: "regex",
+	})
+	consumer := newConsumer(ctx, src, ConsumerOption{
 		DebounceInterval: interval,
 		OnDecodeError: func(source source.Change, err error) {
 		},


### PR DESCRIPTION
## Description
The PR introduced the public function for setting the pgcapture consumer with the specific source other then the one implemented with the DBLogGateway.

