### PR TITLE
feat: set the connection pool size to two for the agent.pg2pulsar commands

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -174,7 +174,11 @@ func (a *Agent) pg2pulsar(params *structpb.Struct) (*pb.AgentConfigResponse, err
 	}
 
 	pgSrc := &source.PGXSource{SetupConnStr: v["PGConnURL"], ReplConnStr: v["PGReplURL"], ReplSlot: trimSlot(v["PulsarTopic"]), CreateSlot: true, CreatePublication: true, StartLSN: v["StartLSN"], DecodePlugin: v["DecodePlugin"]}
-	pulsarSink := &sink.PulsarSink{PulsarOption: pulsar.ClientOptions{URL: v["PulsarURL"]}, PulsarTopic: v["PulsarTopic"]}
+	pulsarSink := &sink.PulsarSink{PulsarOption: pulsar.ClientOptions{
+		URL: v["PulsarURL"],
+		// one for the producer and one for the tracker
+		MaxConnectionsPerBroker: 2,
+	}, PulsarTopic: v["PulsarTopic"]}
 
 	switch v["PulsarTracker"] {
 	case "pulsar", "":


### PR DESCRIPTION

## Description
In the previous implementations, the subscription tracker will always triggered the reconnection process to the pulsar broker.
To solve the issue, the PR adjusted the config of the connection pool size of the corresponding pulsar client to two.
