### PR TITLE
chore: move common functions to the root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ endif
 .PHONY: build
 build:
 	go build \
-		-ldflags="-X github.com/rueian/pgcapture/cmd.CommitSHA=${PGCAPTURE_SHA} -X github.com/rueian/pgcapture/cmd.Version=${PGCAPTURE_VERSION}" \
-		-x -o bin/out/pgcapture main.go
+		-ldflags="-X github.com/rueian/pgcapture.CommitSHA=${PGCAPTURE_SHA} -X github.com/rueian/pgcapture.Version=${PGCAPTURE_VERSION}" \
+		-x -o bin/out/pgcapture ./cmd
 
 .PHONY: test
 test:

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"context"

--- a/cmd/agent_test.go
+++ b/cmd/agent_test.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"reflect"

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"context"

--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"time"

--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"encoding/json"

--- a/cmd/pg2pulsar.go
+++ b/cmd/pg2pulsar.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"github.com/apache/pulsar-client-go/pulsar"

--- a/cmd/pulsar2pg.go
+++ b/cmd/pulsar2pg.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"os"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"fmt"
@@ -36,7 +36,7 @@ var rootCmd = &cobra.Command{
 	},
 }
 
-func Execute() {
+func main() {
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,13 +1,11 @@
-package cmd
+package main
 
 import (
 	"fmt"
 
+	"github.com/rueian/pgcapture"
 	"github.com/spf13/cobra"
 )
-
-var CommitSHA string
-var Version string
 
 func init() {
 	rootCmd.AddCommand(version)
@@ -17,7 +15,7 @@ var version = &cobra.Command{
 	Use:   "version",
 	Short: "git commit version",
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
-		fmt.Printf("version: %s (%s)", Version, CommitSHA)
+		fmt.Printf("version: %s (%s)", pgcapture.Version, pgcapture.CommitSHA)
 		return nil
 	},
 }

--- a/example/client/main.go
+++ b/example/client/main.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/jackc/pgtype"
+	"github.com/rueian/pgcapture"
 	"github.com/rueian/pgcapture/example"
-	"github.com/rueian/pgcapture/pkg/pgcapture"
 	"google.golang.org/grpc"
 )
 

--- a/example/schedule/main.go
+++ b/example/schedule/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/rueian/pgcapture"
 	"github.com/rueian/pgcapture/example"
 	"github.com/rueian/pgcapture/pkg/pb"
 	"google.golang.org/grpc"
@@ -17,7 +18,7 @@ func main() {
 	}
 	defer conn.Close()
 
-	client := pb.NewDBLogControllerClient(conn)
+	client := pgcapture.NewDBLogControllerClient(conn)
 
 	pages, err := example.SinkDB.TablePages(example.TestTable)
 	if err != nil {

--- a/example/server/main.go
+++ b/example/server/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path"
 	"sync"
 	"syscall"
 	"time"
@@ -127,7 +128,7 @@ type cmd struct {
 }
 
 func run(ctx context.Context, cmd cmd, wg *sync.WaitGroup) {
-	args := []string{"run", "main.go", cmd.Name}
+	args := []string{"run", path.Join(".", "cmd"), cmd.Name}
 	for k, v := range cmd.Flags {
 		args = append(args, fmt.Sprintf("--%s=%s", k, v))
 	}

--- a/example/stop/main.go
+++ b/example/stop/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 
+	"github.com/rueian/pgcapture"
 	"github.com/rueian/pgcapture/example"
 	"github.com/rueian/pgcapture/pkg/pb"
 	"google.golang.org/grpc"
@@ -15,7 +16,7 @@ func main() {
 	}
 	defer conn.Close()
 
-	client := pb.NewDBLogControllerClient(conn)
+	client := pgcapture.NewDBLogControllerClient(conn)
 
 	if _, err = client.StopSchedule(context.Background(), &pb.StopScheduleRequest{Uri: example.TestDBSrc}); err != nil {
 		panic(err)

--- a/main.go
+++ b/main.go
@@ -1,7 +1,0 @@
-package main
-
-import "github.com/rueian/pgcapture/cmd"
-
-func main() {
-	cmd.Execute()
-}

--- a/pgcapture.go
+++ b/pgcapture.go
@@ -1,0 +1,45 @@
+package pgcapture
+
+import (
+	"context"
+
+	"github.com/rueian/pgcapture/pkg/dblog"
+	"github.com/rueian/pgcapture/pkg/pb"
+	"github.com/rueian/pgcapture/pkg/pgcapture"
+	"github.com/rueian/pgcapture/pkg/source"
+	"google.golang.org/grpc"
+)
+
+var (
+	CommitSHA string
+	Version   string
+)
+
+type (
+	Model            = pgcapture.Model
+	Change           = pgcapture.Change
+	ModelHandlerFunc = pgcapture.ModelHandlerFunc
+	ConsumerOption   = pgcapture.ConsumerOption
+	SourceResolver   = dblog.SourceResolver
+	SourceDumper     = dblog.SourceDumper
+	RequeueSource    = source.RequeueSource
+)
+
+func NewDBLogConsumer(ctx context.Context, conn *grpc.ClientConn, option ConsumerOption) *pgcapture.Consumer {
+	return pgcapture.NewDBLogConsumer(ctx, conn, option)
+}
+
+func NewDBLogGateway(conn *grpc.ClientConn, sourceResolver SourceResolver) *dblog.Gateway {
+	return &dblog.Gateway{
+		SourceResolver: sourceResolver,
+		DumpInfoPuller: &dblog.GRPCDumpInfoPuller{Client: pb.NewDBLogControllerClient(conn)},
+	}
+}
+
+func NewDBLogControllerClient(conn *grpc.ClientConn) pb.DBLogControllerClient {
+	return pb.NewDBLogControllerClient(conn)
+}
+
+func MarshalJSON(m Model) ([]byte, error) {
+	return pgcapture.MarshalJSON(m)
+}


### PR DESCRIPTION
Previously, developers need to import many different sub-packages and compose them to have a functional pgcapture consumer or gateway.

This PR is aimed to make this library to be more friendly to developers by aliasing commonly used objects to the `github.com/rueian/pgcapture`, not deeper sub-packages. So that developer's import list can be simplified like this:

<img width="461" alt="image" src="https://github.com/rueian/pgcapture/assets/2727535/dbbd4afc-60ef-480c-a579-ebebe72be10e">


To do so, this PR moves the `main` package from the root folder to the `cmd` folder.