### PR TITLE
refactor: remove deprecated pkg and fix typo

### DIFF
--- a/example/reset/main.go
+++ b/example/reset/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/rueian/pgcapture/example"
@@ -14,7 +14,7 @@ func main() {
 	if err != nil {
 		fmt.Println(err)
 	} else {
-		bs, _ := ioutil.ReadAll(resp.Body)
+		bs, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if resp.StatusCode > 299 {
 			fmt.Println(string(bs))

--- a/go.mod
+++ b/go.mod
@@ -66,5 +66,4 @@ require (
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c // indirect
-	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -416,8 +416,6 @@ google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQ
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.38.0 h1:/9BgsAsa5nWe26HqOlvlgJnqBuktYOLCgjCPqsa56W0=
 google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
-google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0 h1:rNBFJjBCOgVr9pWD7rs/knKL4FRTKgpZmsRfV214zcA=
-google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0/go.mod h1:Dk1tviKTvMCz5tvh7t+fh94dhmQVHuCt2OzJB3CTW9Y=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/internal/test/pg.go
+++ b/internal/test/pg.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -72,7 +73,8 @@ func (u DBURL) TablePages(table string) (pages int, err error) {
 
 func CreateDB(u DBURL, n DBURL) (DBURL, error) {
 	if err := u.Exec("create database " + n.DB); err != nil {
-		if pge, ok := err.(*pgconn.PgError); !ok || pge.Code != "42P04" {
+		var pge *pgconn.PgError
+		if !errors.As(err, &pge) || pge.Code != "42P04" {
 			return DBURL{}, err
 		}
 	}

--- a/pkg/cursor/pulsar_sub.go
+++ b/pkg/cursor/pulsar_sub.go
@@ -2,6 +2,7 @@ package cursor
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -111,7 +112,7 @@ func (p *PulsarSubscriptionTracker) Last() (Checkpoint, error) {
 			cp, err := p.read(context.Background())
 			if err != nil {
 				// most likely that there is no message in the topic
-				if err == context.DeadlineExceeded {
+				if errors.Is(err, context.DeadlineExceeded) {
 					return last, nil
 				}
 				return Checkpoint{}, err

--- a/pkg/dblog/control_test.go
+++ b/pkg/dblog/control_test.go
@@ -37,7 +37,7 @@ func TestController_Schedule_Error(t *testing.T) {
 			return context.Canceled
 		},
 	})
-	if _, err := c.Schedule(context.Background(), &pb.ScheduleRequest{}); err != context.Canceled {
+	if _, err := c.Schedule(context.Background(), &pb.ScheduleRequest{}); !errors.Is(err, context.Canceled) {
 		t.Fatal(err)
 	}
 }
@@ -52,7 +52,7 @@ func TestController_PullDumpInfo_InitError(t *testing.T) {
 
 	if err := c.PullDumpInfo(&pdis{
 		RecvCB: func() (*pb.DumpInfoRequest, error) { return &pb.DumpInfoRequest{}, nil },
-	}); err != ErrEmptyURI {
+	}); !errors.Is(err, ErrEmptyURI) {
 		t.Fatal("unexpected")
 	}
 }
@@ -86,7 +86,7 @@ func TestController_PullDumpInfo_Delegate(t *testing.T) {
 			if client != "1" {
 				t.Fatal("unexpected")
 			}
-			if err := fn(dump); err != context.Canceled { // should be received in SendCB
+			if err := fn(dump); !errors.Is(err, context.Canceled) { // should be received in SendCB
 				t.Fatal("unexpected")
 			}
 			return func() {
@@ -117,7 +117,7 @@ func TestController_PullDumpInfo_Delegate(t *testing.T) {
 			}
 			return context.Canceled
 		},
-	}); err != context.Canceled {
+	}); !errors.Is(err, context.Canceled) {
 		t.Fatal("unexpected")
 	}
 

--- a/pkg/dblog/dumper.go
+++ b/pkg/dblog/dumper.go
@@ -109,11 +109,12 @@ func (p *PGXSourceDumper) Stop() {
 	p.mu.Unlock()
 }
 
-// DumpQuery try generate all possible ctids in a given page range.
+// DumpQuery try to generate all possible ctids in a given page range.
 // The maximum rip_posid is caculated as current_setting('block_size')::int-24)/28
-//   where 24 is the size of PageHeaderData, and
-//   where 28 is the minimum size of a tuple which is ItemIdData(4 bytes) + HeapTupleHeaderData(23 bytes) with alignment
-//   ref: https://github.com/postgres/postgres/blob/c3b011d9918100c6ec2d72297fb51635bce70e80/src/include/access/htup_details.h#L573-L575
+//
+//	where 24 is the size of PageHeaderData, and
+//	where 28 is the minimum size of a tuple which is ItemIdData(4 bytes) + HeapTupleHeaderData(23 bytes) with alignment
+//	ref: https://github.com/postgres/postgres/blob/c3b011d9918100c6ec2d72297fb51635bce70e80/src/include/access/htup_details.h#L573-L575
 const DumpQuery = `select * from "%s"."%s" where ctid = any(array(select format('(%%s,%%s)', i, j)::tid from generate_series($1::int,$2::int) as gs(i), generate_series(1,(current_setting('block_size')::int-24)/28) as gs2(j)))`
 
 func (p *PGXSourceDumper) load(minLSN uint64, info *pb.DumpInfoResponse) ([]*pb.Change, error) {
@@ -133,7 +134,8 @@ func (p *PGXSourceDumper) load(minLSN uint64, info *pb.DumpInfoResponse) ([]*pb.
 
 	rows, err := tx.Query(ctx, fmt.Sprintf(DumpQuery, info.Schema, info.Table), info.PageBegin, info.PageEnd)
 	if err != nil {
-		if pge, ok := err.(*pgconn.PgError); ok && pge.Code == "42P01" {
+		var pge *pgconn.PgError
+		if errors.As(err, &pge) && pge.Code == "42P01" {
 			return nil, ErrMissingTable
 		}
 		return nil, err
@@ -163,7 +165,7 @@ func checkLSN(ctx context.Context, tx pgx.Tx, minLSN uint64) (err error) {
 	var str string
 	var lsn pglogrepl.LSN
 	err = tx.QueryRow(ctx, "SELECT commit FROM pgcapture.sources WHERE commit IS NOT NULL ORDER BY commit DESC LIMIT 1").Scan(&str)
-	if err == pgx.ErrNoRows {
+	if errors.Is(err, pgx.ErrNoRows) {
 		return ErrLSNMissing
 	}
 	if err == nil {

--- a/pkg/dblog/dumper_test.go
+++ b/pkg/dblog/dumper_test.go
@@ -2,6 +2,7 @@ package dblog
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/jackc/pglogrepl"
@@ -32,23 +33,23 @@ func TestPGXSourceDumper(t *testing.T) {
 	}
 	defer dumper.Stop()
 
-	if _, err := dumper.LoadDump(0, &pb.DumpInfoResponse{}); err != ErrMissingTable {
+	if _, err := dumper.LoadDump(0, &pb.DumpInfoResponse{}); !errors.Is(err, ErrMissingTable) {
 		t.Fatal(err)
 	}
-	if _, err := dumper.LoadDump(0, &pb.DumpInfoResponse{Schema: "public", Table: "t1"}); err != ErrLSNMissing {
+	if _, err := dumper.LoadDump(0, &pb.DumpInfoResponse{Schema: "public", Table: "t1"}); !errors.Is(err, ErrLSNMissing) {
 		t.Fatal(err)
 	}
 
 	conn.Exec(ctx, "INSERT INTO pgcapture.sources (id,commit) VALUES ($1,$2)", "t1", pglogrepl.LSN(0).String())
 
-	if _, err := dumper.LoadDump(0, &pb.DumpInfoResponse{Schema: "any", Table: "any"}); err != ErrMissingTable {
+	if _, err := dumper.LoadDump(0, &pb.DumpInfoResponse{Schema: "any", Table: "any"}); !errors.Is(err, ErrMissingTable) {
 		t.Fatal(err)
 	}
-	if _, err := dumper.LoadDump(0, &pb.DumpInfoResponse{Schema: "public", Table: "any"}); err != ErrMissingTable {
+	if _, err := dumper.LoadDump(0, &pb.DumpInfoResponse{Schema: "public", Table: "any"}); !errors.Is(err, ErrMissingTable) {
 		t.Fatal(err)
 	}
 
-	if _, err := dumper.LoadDump(100, &pb.DumpInfoResponse{Schema: "public", Table: "t1"}); err != ErrLSNFallBehind {
+	if _, err := dumper.LoadDump(100, &pb.DumpInfoResponse{Schema: "public", Table: "t1"}); !errors.Is(err, ErrLSNFallBehind) {
 		t.Fatal(err)
 	}
 

--- a/pkg/dblog/gateway.go
+++ b/pkg/dblog/gateway.go
@@ -162,7 +162,7 @@ func (s *Gateway) capture(init *pb.CaptureInit, filter *regexp.Regexp, server pb
 				dump, err = dumper.LoadDump(lsn, info.Resp)
 				if err != nil {
 					logger.WithFields(logrus.Fields{"Dump": info.Resp.String()}).Errorf("dump error %v", err)
-					if err != ErrMissingTable {
+					if !errors.Is(err, ErrMissingTable) {
 						info.Ack(err.Error())
 						continue
 					}

--- a/pkg/dblog/gateway_test.go
+++ b/pkg/dblog/gateway_test.go
@@ -24,7 +24,7 @@ func TestGateway_CaptureInitError(t *testing.T) {
 		RecvCB: func() (*pb.CaptureRequest, error) {
 			return nil, context.Canceled
 		},
-	}); err != context.Canceled {
+	}); !errors.Is(err, context.Canceled) {
 		t.Fatal("unexpected")
 	}
 
@@ -33,7 +33,7 @@ func TestGateway_CaptureInitError(t *testing.T) {
 		RecvCB: func() (*pb.CaptureRequest, error) {
 			return &pb.CaptureRequest{}, nil
 		},
-	}); err != ErrCaptureInitMessageRequired {
+	}); !errors.Is(err, ErrCaptureInitMessageRequired) {
 		t.Fatal("unexpected")
 	}
 
@@ -42,7 +42,7 @@ func TestGateway_CaptureInitError(t *testing.T) {
 		RecvCB: func() (*pb.CaptureRequest, error) {
 			return &pb.CaptureRequest{Type: &pb.CaptureRequest_Init{Init: &pb.CaptureInit{Uri: URI1}}}, nil
 		},
-	}); err != context.Canceled {
+	}); !errors.Is(err, context.Canceled) {
 		t.Fatal("unexpected")
 	}
 
@@ -69,7 +69,7 @@ func TestGateway_CaptureInitError(t *testing.T) {
 		RecvCB: func() (*pb.CaptureRequest, error) {
 			return &pb.CaptureRequest{Type: &pb.CaptureRequest_Init{Init: &pb.CaptureInit{Uri: URI1}}}, nil
 		},
-	}); err != context.Canceled {
+	}); !errors.Is(err, context.Canceled) {
 		t.Fatal("unexpected")
 	}
 
@@ -99,7 +99,7 @@ func TestGateway_CaptureInitError(t *testing.T) {
 		RecvCB: func() (*pb.CaptureRequest, error) {
 			return &pb.CaptureRequest{Type: &pb.CaptureRequest_Init{Init: &pb.CaptureInit{Uri: URI1}}}, nil
 		},
-	}); err != context.Canceled {
+	}); !errors.Is(err, context.Canceled) {
 		t.Fatal("unexpected")
 	}
 }
@@ -212,7 +212,7 @@ func TestGateway_Capture(t *testing.T) {
 		t.Fatal("unexpected")
 	}
 
-	// if source have begin, not send it to client, but ack
+	// if source have begun, not send it to client, but ack
 	changes <- source.Change{Checkpoint: cursor.Checkpoint{LSN: 1}, Message: &pb.Message{Type: &pb.Message_Begin{Begin: &pb.Begin{}}}}
 	if cp := <-commit; cp.LSN != 1 {
 		t.Fatal("unexpected")
@@ -374,7 +374,7 @@ func TestGateway_CaptureSendSourceError(t *testing.T) {
 				send <- message
 				return context.Canceled
 			},
-		}); err != context.Canceled {
+		}); !errors.Is(err, context.Canceled) {
 			panic("unexpected")
 		}
 	}()
@@ -459,7 +459,7 @@ func TestGateway_CaptureSendDumpError(t *testing.T) {
 				send <- message
 				return context.Canceled
 			},
-		}); err != context.Canceled {
+		}); !errors.Is(err, context.Canceled) {
 			panic("unexpected")
 		}
 	}()
@@ -555,7 +555,7 @@ func TestGateway_CaptureRecvError(t *testing.T) {
 				send <- message
 				return nil
 			},
-		}); err != context.Canceled {
+		}); !errors.Is(err, context.Canceled) {
 			panic("unexpected")
 		}
 	}()

--- a/pkg/dblog/resolver_test.go
+++ b/pkg/dblog/resolver_test.go
@@ -2,6 +2,7 @@ package dblog
 
 import (
 	"context"
+	"errors"
 	"net"
 	"testing"
 
@@ -12,10 +13,10 @@ import (
 func TestStaticPGXPulsarResolver_ErrURINotFound(t *testing.T) {
 	ctx := context.Background()
 	r := NewStaticAgentPulsarResolver(nil)
-	if _, err := r.Source(ctx, "any"); err != ErrURINotFound {
+	if _, err := r.Source(ctx, "any"); !errors.Is(err, ErrURINotFound) {
 		t.Fatal("unexpected")
 	}
-	if _, err := r.Dumper(ctx, "any"); err != ErrURINotFound {
+	if _, err := r.Dumper(ctx, "any"); !errors.Is(err, ErrURINotFound) {
 		t.Fatal("unexpected")
 	}
 }

--- a/pkg/dblog/scheduler_test.go
+++ b/pkg/dblog/scheduler_test.go
@@ -31,7 +31,7 @@ func TestMemoryScheduler_Schedule(t *testing.T) {
 	}
 
 	for uri, group := range groups {
-		if err := s.Schedule(uri, group.dumps, nil); err != ErrAlreadyScheduled {
+		if err := s.Schedule(uri, group.dumps, nil); !errors.Is(err, ErrAlreadyScheduled) {
 			t.Fatal("scheduled uri should be reject until finished")
 		}
 	}
@@ -59,7 +59,7 @@ func TestMemoryScheduler_Schedule(t *testing.T) {
 
 	for uri, group := range groups {
 		for i := range group.clients {
-			if _, err := s.Register(uri, strconv.Itoa(i), nil); err != ErrAlreadyRegistered {
+			if _, err := s.Register(uri, strconv.Itoa(i), nil); !errors.Is(err, ErrAlreadyRegistered) {
 				t.Fatal("client can't be registered twice until unregistered")
 			}
 		}
@@ -111,7 +111,7 @@ func TestMemoryScheduler_Schedule(t *testing.T) {
 		if err == nil {
 			break
 		}
-		if err == ErrAlreadyRegistered {
+		if errors.Is(err, ErrAlreadyRegistered) {
 			continue
 		}
 		t.Fatal(err)

--- a/pkg/decode/pglogical.go
+++ b/pkg/decode/pglogical.go
@@ -100,7 +100,7 @@ func (p *PGLogicalDecoder) makePBTuple(rel Relation, src []Field, noNull bool) (
 		case 't':
 			fields = append(fields, &pb.Field{Name: rel.Fields[i], Oid: oid, Value: &pb.Field_Text{Text: string(s.Datum)}})
 		case 'u':
-			continue // unchanged toast field should be exclude
+			continue // unchanged toast field should be excluded
 		}
 	}
 	return fields

--- a/pkg/decode/pgoutput.go
+++ b/pkg/decode/pgoutput.go
@@ -90,7 +90,7 @@ func (p *PGOutputDecoder) makePBTuple(rel Relation, src []Field, noNull bool) (f
 		case 't':
 			fields = append(fields, &pb.Field{Name: rel.Fields[i], Oid: oid, Value: &pb.Field_Text{Text: string(s.Datum)}})
 		case 'u':
-			continue // unchanged toast field should be exclude
+			continue // unchanged toast field should be excluded
 		}
 	}
 	return fields

--- a/pkg/sink/postgres.go
+++ b/pkg/sink/postgres.go
@@ -145,7 +145,7 @@ func (p *PGXSink) findCheckpoint(ctx context.Context) (cp cursor.Checkpoint, err
 	var mid []byte
 	var seq uint32
 	err = p.conn.QueryRow(ctx, "SELECT commit, seq, mid FROM pgcapture.sources WHERE id = $1 AND commit IS NOT NULL AND seq IS NOT NULL AND mid IS NOT NULL", p.SourceID).Scan(&str, &seq, &mid)
-	if err == pgx.ErrNoRows {
+	if errors.Is(err, pgx.ErrNoRows) {
 		err = nil
 		if p.LogReader != nil {
 			p.log.Info("try to find last checkpoint from log reader")
@@ -325,7 +325,7 @@ parse:
 		stmts = append(stmts, stmt)
 	}
 
-	// record relations appeared in the statement, following change messages should be ignore if duplicated with them
+	// record relations appeared in the statement, following change messages should be ignored if duplicated with them
 	relations = make(map[string]bool)
 	for _, stmt := range stmts {
 		var relation *pg_query.RangeVar

--- a/pkg/sink/postgres_test.go
+++ b/pkg/sink/postgres_test.go
@@ -2,7 +2,6 @@ package sink
 
 import (
 	"context"
-	"io/ioutil"
 	"log"
 	"os"
 	"strconv"
@@ -529,7 +528,7 @@ func TestPGXSink_ScanCheckpointFromLog(t *testing.T) {
 	conn.Exec(ctx, "DROP SCHEMA public CASCADE; CREATE SCHEMA public")
 	conn.Exec(ctx, "DROP EXTENSION IF EXISTS pgcapture")
 
-	tmp, err := ioutil.TempFile("", "postgres.sql")
+	tmp, err := os.CreateTemp("", "postgres.sql")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/source/postgres.go
+++ b/pkg/source/postgres.go
@@ -77,7 +77,8 @@ func (p *PGXSource) Capture(cp cursor.Checkpoint) (changes chan Change, err erro
 		p.decoder = decode.NewPGOutputDecoder(p.schema, p.ReplSlot)
 		if p.CreatePublication {
 			if _, err = p.setupConn.Exec(ctx, fmt.Sprintf(sql.CreatePublication, p.ReplSlot)); err != nil {
-				if pge, ok := err.(*pgconn.PgError); !ok || pge.Code != "42710" {
+				var pge *pgconn.PgError
+				if !errors.As(err, &pge) || pge.Code != "42710" {
 					return nil, err
 				}
 			}
@@ -88,7 +89,8 @@ func (p *PGXSource) Capture(cp cursor.Checkpoint) (changes chan Change, err erro
 
 	if p.CreateSlot {
 		if _, err = p.setupConn.Exec(ctx, sql.CreateLogicalSlot, p.ReplSlot, p.DecodePlugin); err != nil {
-			if pge, ok := err.(*pgconn.PgError); !ok || pge.Code != "42710" {
+			var pge *pgconn.PgError
+			if !errors.As(err, &pge) || pge.Code != "42710" {
 				return nil, err
 			}
 		}


### PR DESCRIPTION
I remove ioutil pkg and use errors pkg. Also, fix some comment typo.