### PR TITLE
fix: solve the cursor not been replicated issue for the subscription tracker

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/streamnative/pulsar-admin-go v0.1.0
 	google.golang.org/grpc v1.38.0
+	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0
 	google.golang.org/protobuf v1.30.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -435,6 +435,8 @@ google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQ
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.38.0 h1:/9BgsAsa5nWe26HqOlvlgJnqBuktYOLCgjCPqsa56W0=
 google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0 h1:rNBFJjBCOgVr9pWD7rs/knKL4FRTKgpZmsRfV214zcA=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0/go.mod h1:Dk1tviKTvMCz5tvh7t+fh94dhmQVHuCt2OzJB3CTW9Y=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/internal/cursormock/mock.go
+++ b/internal/cursormock/mock.go
@@ -75,3 +75,15 @@ func (mr *MockTrackerMockRecorder) Last() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Last", reflect.TypeOf((*MockTracker)(nil).Last))
 }
+
+// Start mocks base method.
+func (m *MockTracker) Start() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Start")
+}
+
+// Start indicates an expected call of Start.
+func (mr *MockTrackerMockRecorder) Start() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockTracker)(nil).Start))
+}

--- a/internal/tool/main.go
+++ b/internal/tool/main.go
@@ -3,4 +3,7 @@
 
 package tool
 
-import _ "github.com/golang/mock/mockgen"
+import (
+	_ "github.com/golang/mock/mockgen"
+	_ "google.golang.org/grpc/cmd/protoc-gen-go-grpc"
+)

--- a/pkg/cursor/pulsar.go
+++ b/pkg/cursor/pulsar.go
@@ -50,6 +50,10 @@ func (p *PulsarTracker) Last() (last Checkpoint, err error) {
 	}
 }
 
+func (p *PulsarTracker) Start() {
+	// Do Nothing
+}
+
 func (p *PulsarTracker) Commit(_ Checkpoint, _ pulsar.MessageID) error {
 	return nil
 }

--- a/pkg/cursor/pulsar_sub_test.go
+++ b/pkg/cursor/pulsar_sub_test.go
@@ -40,6 +40,9 @@ func TestPulsarSubscriptionTracker_Commit(t *testing.T) {
 	}
 	defer cancel()
 
+	// so it will start the commit loop
+	tracker.Start()
+
 	client, err := pulsar.NewClient(pulsar.ClientOptions{
 		URL: test.GetPulsarURL(),
 	})

--- a/pkg/cursor/tracker.go
+++ b/pkg/cursor/tracker.go
@@ -4,6 +4,7 @@ import "github.com/apache/pulsar-client-go/pulsar"
 
 type Tracker interface {
 	Last() (cp Checkpoint, err error)
+	Start()
 	Commit(cp Checkpoint, mid pulsar.MessageID) error
 	Close()
 }

--- a/pkg/sink/pulsar.go
+++ b/pkg/sink/pulsar.go
@@ -97,6 +97,8 @@ func (p *PulsarSink) Setup() (cp cursor.Checkpoint, err error) {
 }
 
 func (p *PulsarSink) Apply(changes chan source.Change) chan cursor.Checkpoint {
+	p.tracker.Start()
+
 	var first bool
 	return p.BaseSink.apply(changes, func(change source.Change, committed chan cursor.Checkpoint) error {
 		if !first {

--- a/pkg/sink/pulsar_test.go
+++ b/pkg/sink/pulsar_test.go
@@ -37,6 +37,8 @@ func TestPulsarSink(t *testing.T) {
 
 	// test empty checkpoint
 	tracker.EXPECT().Last().Return(cursor.Checkpoint{}, nil)
+	tracker.EXPECT().Start()
+
 	cp, err := sink.Setup()
 	if err != nil {
 		t.Fatal(err)
@@ -76,6 +78,7 @@ func TestPulsarSink(t *testing.T) {
 	// test restart from last message
 	sink = newPulsarSink(topic, tracker)
 	tracker.EXPECT().Last().Return(cursor.Checkpoint{LSN: 3, Seq: 3}, nil)
+	tracker.EXPECT().Start()
 
 	cp, err = sink.Setup()
 	if err != nil {


### PR DESCRIPTION
## Description
The PR is for solving the issue #45 .
In the previous implementations, the consumer of the subscription trackers would not actually consume the incoming messages. As a consequence, the message permits of the consumer would eventually been reduced to zero, and the broker would stop pushing messages to the consumer, which also meant that the consumer's replication snapshot cache would not be able to update to the latest version.
Upon acknowledging these messages, the broker encountered difficulty in locating the relevant replication snapshot within the outdated cache. As a result, the cursor was unable to replicate the latest position to the remote cluster(s).

To solve the issue, the PR added the additional go routine in the subscription tracker to drain the messages in the message queue.


fix #45 

