### PR TITLE
fix(ci): remove deprecated Code Climate coverage reporting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,11 +13,7 @@ commands:
         type: integer
         default: 11
     steps:
-      - run: curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-      - run: chmod +x ./cc-test-reporter
-      - run: ./cc-test-reporter before-build
       - run: PG_VERSION=<< parameters.version >> ./dockerbuild.sh test
-      - run: ./cc-test-reporter after-build -p github.com/replicase/pgcapture --exit-code $?
 
 jobs:
   test-pg-11:


### PR DESCRIPTION
## Summary
- Remove Code Climate coverage reporting from CI pipeline

## Background
Code Climate has deprecated their coverage API entirely. The API endpoint (`api.codeclimate.com/v1/test_reports`) now returns a 301 redirect to `docs.qlty.sh`, causing the test reporter to fail with:
```
Error: invalid character '<' looking for beginning of value
```

## Changes
- Remove cc-test-reporter download, `before-build`, and `after-build` steps
- CI now runs tests only without coverage reporting