### PR TITLE
ci(pg18): add PostgreSQL 18 CI test support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,12 @@ jobs:
       - checkout
       - test-with-pg:
           version: 17
+  test-pg-18:
+    executor: default
+    steps:
+      - checkout
+      - test-with-pg:
+          version: 18
 
 workflows:
   test:
@@ -69,3 +75,4 @@ workflows:
       - test-pg-15
       - test-pg-16
       - test-pg-17
+      - test-pg-18

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,11 @@ services:
     image: replicase/postgres:17-logical
     container_name: postgres17
     hostname: postgres
+  pg_18:
+    <<: *common-pg
+    image: replicase/postgres:18-logical
+    container_name: postgres18
+    hostname: postgres
   pulsar:
     image: apachepulsar/pulsar:2.10.4
     container_name: pulsar

--- a/hack/postgres/18/Dockerfile
+++ b/hack/postgres/18/Dockerfile
@@ -1,0 +1,20 @@
+FROM postgres:18-alpine
+
+RUN wget https://github.com/2ndQuadrant/pglogical/archive/REL2_4_6.tar.gz && \
+    tar -zxvf REL2_4_6.tar.gz && \
+    apk -U add --no-cache build-base libxslt-dev libxml2-dev openssl-dev libedit-dev zlib-dev lz4-dev patch $DOCKER_PG_LLVM_DEPS krb5-pkinit krb5-dev krb5
+
+COPY 18/pglogical/pglogical.patch ./pglogical-REL2_4_6
+
+RUN cd pglogical-REL2_4_6 && \
+    patch -p1 < pglogical.patch && \
+    make USE_PGXS=1 CPPFLAGS="-DPGL_NO_STDIN_ASSIGN" clean all && \
+    make install && \
+    cd / && \
+    rm -rf /REL2_4_6.tar.gz /pglogical-REL2_4_6
+
+RUN chown -R postgres:postgres /usr/local/share/postgresql/extension
+RUN chown -R postgres:postgres /usr/local/lib/postgresql
+
+COPY ./extension /extension
+RUN cd /extension && ./make.sh

--- a/hack/postgres/18/pglogical/pglogical.patch
+++ b/hack/postgres/18/pglogical/pglogical.patch
@@ -1,0 +1,34 @@
+diff -Naur old/pglogical_output_plugin.c new/pglogical_output_plugin.c
+--- old/pglogical_output_plugin.c	2023-10-04 09:54:00
++++ new/pglogical_output_plugin.c	2023-10-24 21:27:44
+@@ -189,7 +189,7 @@
+ 	{
+ 		int		params_format;
+ 		bool	started_tx = false;
+-		PGLogicalLocalNode *node;
++//		PGLogicalLocalNode *node;
+ 		MemoryContext oldctx;
+ 
+ 		/*
+@@ -208,8 +208,8 @@
+ 			StartTransactionCommand();
+ 			started_tx = true;
+ 		}
+-		node = get_local_node(false, false);
+-		data->local_node_id	= node->node->id;
++//		node = get_local_node(false, false);
++//		data->local_node_id	= node->node->id;
+ 
+ 		 /*
+ 		 * Ideally we'd send the startup message immediately. That way
+@@ -669,8 +669,8 @@
+ 	old = MemoryContextSwitchTo(data->context);
+ 
+ 	/* First check the table filter */
+-	if (!pglogical_change_filter(data, relation, change, &att_list))
+-		goto cleanup;
++//	if (!pglogical_change_filter(data, relation, change, &att_list))
++//		goto cleanup;
+ 
+ 	/*
+ 	 * If the protocol wants to write relation information and the client


### PR DESCRIPTION
## Summary
Add PostgreSQL 18 support to the CI test suite.

## Changes
- Add `test-pg-18` job in CircleCI config
- Add `pg_18` service in docker-compose.yml
- Create `hack/postgres/18/Dockerfile` using pglogical REL2_4_6 (officially supports PG18)
- Copy pglogical patch for PG18