### PR TITLE
feat(source): add Tables filter and dynamic publication management

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/replicase/pgcapture/pkg/decode"
@@ -27,6 +28,7 @@ var (
 	ConfigPulsarTrackerReplicateState bool
 	ConfigDecodePlugin                string
 	ConfigBatchTXSize                 int
+	ConfigTables                      []string
 )
 
 func init() {
@@ -44,6 +46,7 @@ func init() {
 	configure.Flags().BoolVarP(&ConfigPulsarTrackerReplicateState, "PulsarTrackerReplicateState", "", false, "the replicate state for the pg2pulsar, optional")
 	configure.Flags().StringVarP(&ConfigDecodePlugin, "DecodePlugin", "", decode.PGOutputPlugin, "the logical decoding plugin name")
 	configure.Flags().IntVarP(&ConfigBatchTXSize, "BatchTxSize", "", 100, "the max number of tx in a pipeline")
+	configure.Flags().StringSliceVar(&ConfigTables, "Tables", nil, "tables to capture (e.g., public.users,public.orders); empty for all tables (pgoutput plugin only)")
 	configure.MarkFlagRequired("AgentAddr")
 	configure.MarkFlagRequired("AgentCommand")
 	configure.MarkFlagRequired("PGConnURL")
@@ -68,6 +71,7 @@ var configure = &cobra.Command{
 			"PulsarTrackerReplicateState": strconv.FormatBool(ConfigPulsarTrackerReplicateState),
 			"DecodePlugin":                ConfigDecodePlugin,
 			"BatchTxSize":                 ConfigBatchTXSize,
+			"Tables":                      strings.Join(ConfigTables, ","),
 		})
 		if err != nil {
 			panic(err)

--- a/cmd/pg2pulsar.go
+++ b/cmd/pg2pulsar.go
@@ -14,6 +14,7 @@ var (
 	SinkPulsarURL   string
 	SinkPulsarTopic string
 	DecodePlugin    string
+	SourceTables    []string
 )
 
 func init() {
@@ -23,6 +24,7 @@ func init() {
 	pg2pulsar.Flags().StringVarP(&SinkPulsarURL, "PulsarURL", "", "", "connection url to sink pulsar cluster")
 	pg2pulsar.Flags().StringVarP(&SinkPulsarTopic, "PulsarTopic", "", "", "the sink pulsar topic name and as well as the logical replication slot name")
 	pg2pulsar.Flags().StringVar(&DecodePlugin, "DecodePlugin", decode.PGOutputPlugin, "the logical decoding plugin name")
+	pg2pulsar.Flags().StringSliceVar(&SourceTables, "Tables", nil, "tables to capture (e.g., public.users,public.orders); empty for all tables (pgoutput plugin only)")
 	pg2pulsar.MarkFlagRequired("PGConnURL")
 	pg2pulsar.MarkFlagRequired("PGReplURL")
 	pg2pulsar.MarkFlagRequired("PulsarURL")
@@ -33,7 +35,7 @@ var pg2pulsar = &cobra.Command{
 	Use:   "pg2pulsar",
 	Short: "Capture logical replication logs to a Pulsar Topic from a PostgreSQL logical replication slot",
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
-		pgSrc := &source.PGXSource{SetupConnStr: SourcePGConnURL, ReplConnStr: SourcePGReplURL, ReplSlot: trimSlot(SinkPulsarTopic), CreateSlot: true, CreatePublication: true, DecodePlugin: DecodePlugin}
+		pgSrc := &source.PGXSource{SetupConnStr: SourcePGConnURL, ReplConnStr: SourcePGReplURL, ReplSlot: trimSlot(SinkPulsarTopic), CreateSlot: true, CreatePublication: true, DecodePlugin: DecodePlugin, Tables: source.ParseTableIdents(SourceTables...)}
 		pulsarSink := &sink.PulsarSink{PulsarOption: pulsar.ClientOptions{URL: SinkPulsarURL}, PulsarTopic: SinkPulsarTopic}
 		return sourceToSink(pgSrc, pulsarSink)
 	},

--- a/pkg/sql/source.go
+++ b/pkg/sql/source.go
@@ -21,6 +21,16 @@ var CreateLogicalSlot = `SELECT pg_create_logical_replication_slot($1, $2);`
 
 var CreatePublication = `CREATE PUBLICATION %s FOR ALL TABLES;`
 
+var CreatePublicationForTables = `CREATE PUBLICATION %s FOR TABLE %s;`
+
+var QueryPublication = `SELECT puballtables FROM pg_publication WHERE pubname = $1;`
+
+var QueryPublicationTables = `SELECT schemaname, tablename FROM pg_publication_tables WHERE pubname = $1;`
+
+var DropPublication = `DROP PUBLICATION %s;`
+
+var AlterPublicationSetTable = `ALTER PUBLICATION %s SET TABLE %s;`
+
 var InstallExtension = `CREATE EXTENSION IF NOT EXISTS pgcapture;`
 
 var ServerVersionNum = `SHOW server_version_num;`


### PR DESCRIPTION
## Summary
- Add `Tables` option to filter which tables are published via pgoutput plugin
- Implement dynamic publication management that detects and updates publication configuration on restart
- Always include `pgcapture.ddl_logs` table for DDL replication

## Changes
- `pkg/source/postgres.go`: Add `TableIdent` type, `publicationAction` enum, `getPublicationAction()` and `ensurePublication()` for dynamic publication management
- `pkg/sql/source.go`: Add SQL statements for querying and modifying publications
- `cmd/pg2pulsar.go`, `cmd/agent.go`: Integrate `--Tables` CLI option
- `pkg/source/postgres_test.go`: Add comprehensive tests for table filtering and publication management