### PR TITLE
feat: Add pg19 compatibility to pgcapture

### DIFF
--- a/hack/postgres/extension/pg_import.c
+++ b/hack/postgres/extension/pg_import.c
@@ -7,7 +7,7 @@
 
 #include "postgres.h"
 
-#if PG_VERSION_NUM < 120000
+#if PG_VERSION_NUM < 120000 || PG_VERSION_NUM >= 190000
 #include "access/htup_details.h"
 #endif
 #if PG_VERSION_NUM >= 160000

--- a/hack/postgres/extension/pgcapture.c
+++ b/hack/postgres/extension/pgcapture.c
@@ -338,6 +338,9 @@ extract_query_text(PlannedStmt *pstmt, const char *query, int query_location,
 				RawStmt    *rawstmt;
 				Query	   *viewParse;
 				RangeVar   *rv = view->view;
+#if PG_VERSION_NUM >= 190000
+				ObjectAddress temp_object;
+#endif
 
 				/* Explicit CREATE TEMP VIEW? */
 				if (rv->relpersistence == RELPERSISTENCE_TEMP)
@@ -355,7 +358,7 @@ extract_query_text(PlannedStmt *pstmt, const char *query, int query_location,
 				viewParse = parse_analyze_fixedparams(rawstmt, query, NULL, 0,
 													  NULL);
 
-				if (isQueryUsingTempRelation(viewParse))
+				if (query_uses_temp_object(viewParse, &temp_object))
 					return NULL;
 
 				break;

--- a/hack/postgres/extension/pgcapture.h
+++ b/hack/postgres/extension/pgcapture.h
@@ -7,6 +7,9 @@
 #ifndef PGCAPTURE_H
 #define PGCAPTURE_H
 
+#if PG_VERSION_NUM < 190000
+#define query_uses_temp_object(q, t) isQueryUsingTempRelation(q)
+#endif
 #if PG_VERSION_NUM < 150000
 #define parse_analyze_fixedparams(a,b,c,d,e) parse_analyze(a,b,c,d,e)
 #endif


### PR DESCRIPTION
The `isQueryUsingTempRelation(query)` function has been replaced by a new `query_uses_temp_object(query, address)` function.  The code uses the new function (and new parameters) and relies on a macro for backward compatibility.

Some headers have also been changed upstream and it's now necessary to explicitly import access/htup_details.h.